### PR TITLE
Add comment about how to import commonJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Redux Persist is [performant](#why-redux-persist), easy to [implement](#usage), 
 [API Docs](./docs/api.md)
 ```js
 import { persistStore, persistCombineReducers } from 'redux-persist'
-import storage from 'redux-persist/es/storage' // default: localStorage if web, AsyncStorage if react-native
+import storage from 'redux-persist/es/storage' // default: localStorage if web, AsyncStorage if react-native. *Note*: Use 'redux-persist/lib/storage' to import commonjs
 import reducers from './reducers' // where reducers is an object of reducers
 
 const config = {


### PR DESCRIPTION
We *shamefully* have an older version of webpack running, and this one bit me for a few minutes. Thought I would provide this note.